### PR TITLE
rtpengine: export subscribe operation functions

### DIFF
--- a/src/modules/rtpengine/api.h
+++ b/src/modules/rtpengine/api.h
@@ -27,11 +27,22 @@
 #define _RTPENGINE_API_H_
 
 #include "../../core/parser/msg_parser.h"
+#include "./rtpengine.h"
 
 typedef int (*rtpengine_start_recording_f)(struct sip_msg *msg);
-typedef int (*rtpengine_answer_f)(struct sip_msg *msg, str *str);
-typedef int (*rtpengine_offer_f)(struct sip_msg *msg, str *str);
-typedef int (*rtpengine_delete_f)(struct sip_msg *msg, str *str);
+typedef int (*rtpengine_answer_f)(
+		struct sip_msg *msg, str *flags, str *viabranch);
+typedef int (*rtpengine_offer_f)(
+		struct sip_msg *msg, str *flags, str *viabranch);
+typedef int (*rtpengine_delete_f)(
+		struct sip_msg *msg, str *flags, str *viabranch);
+typedef int (*rtpengine_subscribe_request_f)(struct rtpengine_session *sess,
+		str **to_tag, str *flags, unsigned int subscribe_flags, str *ret_body,
+		struct rtpengine_streams *ret_streams);
+typedef int (*rtpengine_subscribe_answer_f)(
+		struct rtpengine_session *sess, str *to_tag, str *flags, str *body);
+typedef int (*rtpengine_unsubscribe_f)(
+		struct rtpengine_session *sess, str *to_tag, str *flags);
 
 typedef struct rtpengine_api
 {
@@ -39,6 +50,9 @@ typedef struct rtpengine_api
 	rtpengine_answer_f rtpengine_answer;
 	rtpengine_offer_f rtpengine_offer;
 	rtpengine_delete_f rtpengine_delete;
+	rtpengine_subscribe_request_f rtpengine_subscribe_request;
+	rtpengine_subscribe_answer_f rtpengine_subscribe_answer;
+	rtpengine_unsubscribe_f rtpengine_unsubscribe;
 } rtpengine_api_t;
 
 typedef int (*bind_rtpengine_f)(rtpengine_api_t *api);

--- a/src/modules/rtpengine/rtpengine.h
+++ b/src/modules/rtpengine/rtpengine.h
@@ -28,9 +28,11 @@
 #include "bencode.h"
 #include "../../core/str.h"
 #include "../../core/locking.h"
+#include "rtpengine_common.h"
 
 #define RTPENGINE_MIN_RECHECK_TICKS 0
 #define RTPENGINE_MAX_RECHECK_TICKS ((unsigned int)-1)
+#define RTPENGINE_ALL_BRANCHES -1
 
 enum rtpe_operation
 {
@@ -52,6 +54,9 @@ enum rtpe_operation
 	OP_PLAY_MEDIA,
 	OP_STOP_MEDIA,
 	OP_PLAY_DTMF,
+	OP_SUBSCRIBE_REQUEST,
+	OP_SUBSCRIBE_ANSWER,
+	OP_UNSUBSCRIBE,
 
 	OP_ANY,
 };
@@ -124,6 +129,16 @@ enum hash_algo_t
 	RTP_HASH_CALLID,
 	RTP_HASH_SHA1_CALLID,
 	RTP_HASH_CRC32_CALLID
+};
+
+struct rtpengine_session
+{
+	struct sip_msg *msg;
+	int branch;
+	str *callid;
+	str *from_tag;
+	str *to_tag;
+	str *body;
 };
 
 #endif

--- a/src/modules/rtpengine/rtpengine_common.h
+++ b/src/modules/rtpengine/rtpengine_common.h
@@ -1,0 +1,28 @@
+#ifndef _RTPENGINE_COMMON_H_
+#define _RTPENGINE_COMMON_H_
+
+#define RTPENGINE_CALLER 0
+#define RTPENGINE_CALLEE 1
+
+#define RTP_SUBSCRIBE_MODE_SIPREC (1 << 0)
+#define RTP_SUBSCRIBE_MODE_DISABLE (1 << 1)
+
+#define RTP_COPY_LEG_CALLER (1 << 2)
+#define RTP_COPY_LEG_CALLEE (1 << 3)
+#define RTP_COPY_LEG_BOTH (RTP_COPY_LEG_CALLER | RTP_COPY_LEG_CALLEE)
+#define RTP_COPY_MAX_STREAMS 32
+
+struct rtpengine_stream
+{
+	int leg;
+	int medianum;
+	int label;
+};
+
+struct rtpengine_streams
+{
+	int count;
+	struct rtpengine_stream streams[RTP_COPY_MAX_STREAMS];
+};
+
+#endif /* _RTPENGINE_COMMON_H_ */


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [x] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Ability to forke media is added to rtpengine module. Functions are exported to send  subscribe request, subscribe answer and unsubscribe commands to rtpengine to handle media forking.