### PR TITLE
Feature/11 ims icscf i scscf next

### DIFF
--- a/misc/examples/ims/icscf/kamailio.cfg
+++ b/misc/examples/ims/icscf/kamailio.cfg
@@ -426,7 +426,7 @@ onreply_route[register_reply]
 failure_route[register_failure]
 {
 	if (t_branch_timeout() || t_check_status("([5-6][0-9][0-9])")){
-		if (I_scscf_select("1")) {
+		if(I_scscf_next() && I_scscf_select("1") ){
 			t_on_reply("register_reply");
 			t_on_failure("register_failure");
 			if (!t_relay()) {

--- a/src/modules/ims_icscf/doc/ims_icscf_admin.xml
+++ b/src/modules/ims_icscf/doc/ims_icscf_admin.xml
@@ -475,6 +475,24 @@ route[SESSION_LIR_REPLY]
         </programlisting>
       </example>
     </section>
+    <section>
+      <title><function moreinfo="none">I_scscf_next()</function></title>
+
+      <para>If there is more than one entry in the list of SCSCFs drop the top entry.</para>
+
+      <para>It returns true(1) if there is another SCSCF entry; otherwise false(-1).</para>
+
+      <para>This function can be used from FAILURE_ROUTE | REPLY_ROUTE.</para>
+
+      <example>
+        <title><function moreinfo="none">I_scscf_next</function> usage</title>
+
+        <programlisting format="linespecific">...
+I_scscf_next();
+...
+</programlisting>
+      </example>
+    </section>
   </section>
 
   <section>

--- a/src/modules/ims_icscf/ims_icscf_mod.c
+++ b/src/modules/ims_icscf/ims_icscf_mod.c
@@ -128,6 +128,7 @@ static cmd_export_t cmds[] = {
 		0, 0, REQUEST_ROUTE | FAILURE_ROUTE},
 	{"I_scscf_drop", (cmd_function)I_scscf_drop, 0,
 		0, 0, REQUEST_ROUTE | ONREPLY_ROUTE | FAILURE_ROUTE},
+		{"I_scscf_next", (cmd_function)I_scscf_next, 0, 0, 0, ONREPLY_ROUTE | FAILURE_ROUTE},
 	{0, 0, 0, 0, 0, 0}
 };
 

--- a/src/modules/ims_icscf/scscf_list.h
+++ b/src/modules/ims_icscf/scscf_list.h
@@ -149,8 +149,14 @@ void i_lock(unsigned int hash);
 void i_unlock(unsigned int hash);
 int I_scscf_select(struct sip_msg *msg, char *str1, char *str2);
 
-int I_scscf_next(struct sip_msg *msg, char *str1, char *str2);
+
+/**
+ * Drops the top entry of S-CSCF list for call id (if more entries exists).
+ * @param call_id - the id of the call
+ * @returns -1 if no other entry exists, otherwise +1
+ */
 int skip_scscf(str call_id);
+int I_scscf_next(struct sip_msg *msg, char *str1, char *str2);
 
 /**
  * Takes on S-CSCF name for the respective Call-ID from the respective name list.

--- a/src/modules/ims_icscf/scscf_list.h
+++ b/src/modules/ims_icscf/scscf_list.h
@@ -149,6 +149,9 @@ void i_lock(unsigned int hash);
 void i_unlock(unsigned int hash);
 int I_scscf_select(struct sip_msg *msg, char *str1, char *str2);
 
+int I_scscf_next(struct sip_msg *msg, char *str1, char *str2);
+int skip_scscf(str call_id);
+
 /**
  * Takes on S-CSCF name for the respective Call-ID from the respective name list.
  * Don't free the result.s - it is freed later!


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
In ims_icscf module, an ordered list of S-CSCFs is stored for each call id.  
However previously there was no command to use entries other than the first (top) one.  
In case of S-CSCF failure, the I_scscf_drop() command was used,  
 but this would drop the entire list instead of just the failed S-CSCF.


This PR introduces a new command, I_scscf_next(), which allows dropping the top entry from S-CSCFs list(if additional entries exist).  
This provides more granular control and allows fallback to the next available S-CSCF in the list.
