### PR TITLE
Feature/12 add rtp timeout warning

### DIFF
--- a/src/modules/ims_dialog/ims_dialog.c
+++ b/src/modules/ims_dialog/ims_dialog.c
@@ -383,6 +383,7 @@ static int w_dlg_get(struct sip_msg *msg, char *ci, char *ft, char *tt)
 	set_current_dialog(msg, dlg);
 	_dlg_ctx.dlg = dlg;
 	_dlg_ctx.dir = dir;
+	dlg_set_ctx_iuid(dlg);
 	return 1;
 }
 

--- a/src/modules/rtpengine/doc/rtpengine_admin.xml
+++ b/src/modules/rtpengine/doc/rtpengine_admin.xml
@@ -2292,6 +2292,101 @@ modparam("rtpengine", "dtmf_event", "$avp(dtmf_event)")
 		</example>
 	</section>
 
+
+	<section id="rtpengine.p.timeout_event_callid">
+		<title><varname>timeout_event_callid</varname> (string)</title>
+		<para>
+			The name of a pseudovariable to be filled in with the callid of the triggered timeout event.
+		</para>
+		<para>
+			By default, this parameter is not set.
+		</para>
+		<example>
+		<title>Set <varname>timeout_event_callid</varname> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("rtpengine", "timeout_event_callid", "$avp(timeout_event_callid)")
+...
+</programlisting>
+		</example>
+	</section>
+
+
+	<section id="rtpengine.p.timeout_event_src_tag">
+		<title><varname>timeout_event_src_tag</varname> (string)</title>
+		<para>
+			The name of a pseudovariable to be filled in with the source tag for 
+			the packet stream that triggered the timeout event.
+		</para>
+		<para>
+			By default, this parameter is not set.
+		</para>
+		<example>
+		<title>Set <varname>timeout_event_src_tag</varname> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("rtpengine", "timeout_event_src_tag", "$avp(timeout_event_src_tag)")
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="rtpengine.p.timeout_event_dst_tags">
+		<title><varname>timeout_event_dst_tags</varname> (string)</title>
+		<para>
+			The name of a pseudovariable to be filled in with the destination tags
+			for the packet stream that triggered the timeout event.
+		</para>
+		<para>
+			By default, this parameter is not set.
+		</para>
+		<example>
+		<title>Set <varname>timeout_event_dst_tags</varname> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("rtpengine", "timeout_event_dst_tags", "$avp(timeout_event_dst_tags)")
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="rtpengine.p.timeout_event_source_ip">
+		<title><varname>timeout_event_source_ip</varname> (string)</title>
+		<para>
+			The name of a pseudovariable to be filled in with the source ip of the packet stream
+			that triggered the timeout event.
+		</para>
+		<para>
+			By default, this parameter is not set.
+		</para>
+		<example>
+		<title>Set <varname>timeout_event_source_ip</varname> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("rtpengine", "timeout_event_source_ip", "$avp(timeout_event_source_ip)")
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="rtpengine.p.timeout_event_timestamp">
+		<title><varname>timeout_event_timestamp</varname> (string)</title>
+		<para>
+			The name of a pseudovariable to be filled in with the timestamp when the timeout event triggered.
+		</para>
+		<para>
+			By default, this parameter is not set.
+		</para>
+		<example>
+		<title>Set <varname>timeout_event_timestamp</varname> parameter</title>
+<programlisting format="linespecific">
+...
+modparam("rtpengine", "timeout_event_timestamp", "$avp(timeout_event_timestamp)")
+...
+</programlisting>
+		</example>
+	</section>
+
 	<section id="rtpengine.p.control_cmd_tos">
 		<title><varname>control_cmd_tos</varname> (integer)</title>
 		<para>
@@ -2375,6 +2470,29 @@ modparam("rtpengine", "wsapi", "lwsc")
 		<programlisting format="linespecific">
 ...
 modparam("rtpengine", "dtmf_events_sock", "127.0.0.1:2223")
+...
+</programlisting>
+		</example>
+	</section>
+
+	<section id="rtpengine.p.timeout_events_sock" xreflabel="timeout_events_sock">
+		<title><varname>timeout_events_sock</varname> (string)</title>
+		<para>
+		Definition of IPv4/IPv6 UDP socket used to receive timeout warnings from RTPEngine.
+		</para>
+		<para>
+		Timeout warnings coming from RTPEngine will trigger rtpengine:timeout-event route.
+		</para>
+		<para>
+			<emphasis>
+				Default value is <quote>NONE</quote> (disabled).
+			</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>timeout_events_sock</varname> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("rtpengine", "timeout_events_sock", "127.0.0.1:2228")
 ...
 </programlisting>
 		</example>


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask on sr-dev mailing list -->
- [x] Commit message has the format required by CONTRIBUTING guide
- [x] Commits are split per component (core, individual modules, libs, utils, ...)
- [x] Each component has a single commit (if not, squash them into one commit)
- [x] No commits to README files for modules (changes must be done to docbook files
in `doc/` subfolder, the README file is autogenerated)

#### Type Of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->
Similar to the DTMF event, a timeout warning event is added to the rtpengine.
This event is triggered when there is no rtp/rtcp traffic for a packet stream in rtpengine, 
This PR introduces corresponding parameters and event route(rtpengine:timeout-event) to manage this event.
Additionally, it includes a small fix in the ims_dialog module:dlg_get where the context’s iuid was not being set after the dialog was found.